### PR TITLE
Update cfn-tools.sh

### DIFF
--- a/scripts/cfn-tools.sh
+++ b/scripts/cfn-tools.sh
@@ -236,7 +236,7 @@ qs_aws-cfn-bootstrap() {
   qs_get-osversion INSTANCE_OSVERSION
 
   echo "[INSTALL aws-cfn-bootstrap tools]"
-  if [[ "$INSTANCE_OSTYPE" == "amzn" && ( "$INSTANCE_OSVERSION" == "2" || "$INSTANCE_OSVERSION" == "2022" ) ]]; then
+  if [[ "$INSTANCE_OSTYPE" == "amzn" && ( "$INSTANCE_OSVERSION" == "2" || "$INSTANCE_OSVERSION" == "2023" ) ]]; then
     cp scripts/opt-aws.sh /etc/profile.d/
     ln -s /opt/aws/bin/cfn-* /usr/bin/
     export PATH=$PATH:/opt/aws/bin


### PR DESCRIPTION
Change OS Version from 2022 to 2023 to reflect changes from AL2022 to 2023 in [cfn-ps-linux-bastion](https://github.com/aws-ia/cfn-ps-linux-bastion/tree/main)/[scripts](https://github.com/aws-ia/cfn-ps-linux-bastion/tree/main/scripts)
 
I did not see 2022 used elsewhere for version checking. 

Prior to fix, the `qs_aws-cfn-bootstrap` function would end with:
```
+ echo '[INSTALL aws-cfn-bootstrap tools]'
[INSTALL aws-cfn-bootstrap tools]
+ [[ amzn == \a\m\z\n ]]
+ [[ 2023 == \2 ]]
+ [[ 2023 == \2\0\2\2 ]]
+ '[' amzn == ubuntu ']'
+ '[' amzn == centos ']'
+ '[' amzn == sles ']'
+ exit 1
exit
```

Tested with simply the command `qs_aws-cfn-bootstrap` on a quick launch AL2023 instance. 